### PR TITLE
Add Codex support + runtime-agnostic skill flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,10 @@ What went wrong?
 
 What you expected instead.
 
+## Runtime
+
+<!-- Claude or Codex -->
+
 ## Model
 
-<!-- e.g. claude-sonnet-4-6 -->
+<!-- e.g. claude-sonnet-4-6 / gpt-5 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,4 +33,4 @@ Describe how you tested the skill. Paste a representative input/output pair:
 
 - [ ] No API keys, tokens, or sensitive data included
 - [ ] No fabricated examples — outputs must reflect real model responses
-- [ ] Skill works with Claude Code CLI, VS Code, and Cursor
+- [ ] Skill works with Claude Code CLI / VS Code / Cursor and Codex

--- a/.github/workflows/skill-smoke.yml
+++ b/.github/workflows/skill-smoke.yml
@@ -1,0 +1,72 @@
+name: Skill Smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - 'solidity-auditor/**'
+      - '.github/workflows/skill-smoke.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate skill structure
+        run: |
+          set -euo pipefail
+
+          required_files=(
+            "solidity-auditor/SKILL.md"
+            "solidity-auditor/VERSION"
+            "solidity-auditor/README.md"
+            "solidity-auditor/agents/openai.yaml"
+            "solidity-auditor/references/judging.md"
+            "solidity-auditor/references/report-formatting.md"
+            "solidity-auditor/references/agents/vector-scan-agent.md"
+            "solidity-auditor/references/agents/adversarial-reasoning-agent.md"
+            "solidity-auditor/references/attack-vectors/attack-vectors-1.md"
+            "solidity-auditor/references/attack-vectors/attack-vectors-2.md"
+            "solidity-auditor/references/attack-vectors/attack-vectors-3.md"
+            "solidity-auditor/references/attack-vectors/attack-vectors-4.md"
+          )
+
+          for file in "${required_files[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing required file: $file"
+              exit 1
+            fi
+          done
+
+          frontmatter=$(awk '
+            NR == 1 { if ($0 != "---") exit 2; next }
+            $0 == "---" { exit }
+            { print }
+          ' solidity-auditor/SKILL.md) || {
+            echo "Invalid SKILL.md frontmatter"
+            exit 1
+          }
+
+          echo "$frontmatter" | grep -Eq '^name:[[:space:]]*solidity-auditor$' || {
+            echo "SKILL.md missing required frontmatter field: name"
+            exit 1
+          }
+
+          echo "$frontmatter" | grep -Eq '^description:[[:space:]]*.+$' || {
+            echo "SKILL.md missing required frontmatter field: description"
+            exit 1
+          }
+
+          grep -Eq '^policy:' solidity-auditor/agents/openai.yaml || {
+            echo "openai.yaml missing policy block"
+            exit 1
+          }
+
+          grep -Eq 'allow_implicit_invocation:[[:space:]]*false' solidity-auditor/agents/openai.yaml || {
+            echo "openai.yaml must set allow_implicit_invocation: false"
+            exit 1
+          }
+
+          echo "Skill smoke checks passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 - [ ] No API keys, tokens, or sensitive data
 - [ ] No fabricated examples — outputs must reflect real model responses
-- [ ] Skill works with Claude Code CLI, VS Code, and Cursor
+- [ ] Skill works with Claude Code CLI / VS Code / Cursor and Codex
 
 ## What to Contribute
 
@@ -26,6 +26,7 @@
 Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md) issue template and include:
 
 - Which skill is affected and how you invoked it.
-- The Claude model used (e.g., claude-sonnet-4-6).
+- Runtime used (Claude or Codex).
+- Model used.
 - The input you gave and the output you got.
 - What you expected instead.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pashov Audit Group Skills
 
-> Claude Code skills for Solidity security and development — built by [Pashov Audit Group](https://www.pashov.com/).
+> AI skills for Solidity security and development — built by [Pashov Audit Group](https://www.pashov.com/).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -9,18 +9,30 @@
 
 ## Install & Run
 
-Works with the **Claude Code CLI**, the **VS Code Claude extension**, and **Cursor**. Run the following in your terminal:
+### Claude Code (CLI, VS Code extension, Cursor)
 
 ```bash
 git clone https://github.com/pashov/skills.git && cp -r skills/solidity-auditor ~/.claude/commands/solidity-auditor
 ```
 
-The skill is then invocable as `/solidity-auditor`. See the [skill README](solidity-auditor/README.md) for usage.
+Invoke with `/solidity-auditor`. See the [skill README](solidity-auditor/README.md) for usage.
 
-**Update to latest:** `cd` into the cloned `skills` repo and run:
+### Codex
 
 ```bash
-git pull && cp -r solidity-auditor ~/.claude/commands/solidity-auditor
+git clone https://github.com/pashov/skills.git && mkdir -p ~/.agents/skills/solidity-auditor && cp -r skills/solidity-auditor/. ~/.agents/skills/solidity-auditor/
+```
+
+Restart Codex after install. Invoke with `$solidity-auditor` (or select it via `/skills`).
+
+### Update to latest
+
+`cd` into the cloned `skills` repo and run:
+
+```bash
+git pull
+cp -r solidity-auditor ~/.claude/commands/solidity-auditor
+mkdir -p ~/.agents/skills/solidity-auditor && cp -r solidity-auditor/. ~/.agents/skills/solidity-auditor/
 ```
 
 ---

--- a/solidity-auditor/README.md
+++ b/solidity-auditor/README.md
@@ -18,6 +18,8 @@ _Portrayed below: finding multiple high-confidence vulnerabilities in a codebase
 
 ## Usage
 
+### Claude
+
 ```bash
 # Scan the full repo (default)
 /solidity-auditor
@@ -31,6 +33,16 @@ _Portrayed below: finding multiple high-confidence vulnerabilities in a codebase
 
 # Write report to a markdown file (terminal-only by default)
 /solidity-auditor --file-output
+```
+
+### Codex
+
+```text
+$solidity-auditor
+$solidity-auditor deep
+$solidity-auditor src/Vault.sol
+$solidity-auditor src/Vault.sol src/Router.sol
+$solidity-auditor --file-output
 ```
 
 ## Known Limitations

--- a/solidity-auditor/SKILL.md
+++ b/solidity-auditor/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: solidity-auditor
-description: Security audit of Solidity code while you develop. Trigger on "audit", "check this contract", "review for security". Modes - default (full repo), DEEP (+ adversarial reasoning), or a specific filename.
+description: Security audit of Solidity code while you develop. Trigger on "audit", "check this contract", "review for security". Modes - default (full repo), deep (+ adversarial reasoning), or specific filename(s).
 ---
 
 # Smart Contract Security Audit
 
-You are the orchestrator of a parallelized smart contract security audit. Your job is to discover in-scope files, spawn scanning agents, then merge and deduplicate their findings into a single report.
+You orchestrate a parallelized smart contract security audit. Discover in-scope files, run scanning agents, then merge and deduplicate findings into one report.
+
+## Runtime Compatibility
+
+Use whichever shell, file-read, and sub-agent tools are available in your runtime. Prefer parallel execution when available. If a capability is unavailable, run an equivalent sequential fallback without changing audit logic.
 
 ## Mode Selection
 
 **Exclude pattern** (applies to all modes): skip directories `interfaces/`, `lib/`, `mocks/`, `test/` and files matching `*.t.sol`, `*Test*.sol` or `*Mock*.sol`.
 
-- **Default** (no arguments): scan all `.sol` files using the exclude pattern. Use Bash `find` (not Glob) to discover files.
+- **Default** (no arguments): scan all `.sol` files using the exclude pattern. Use shell `find` (not glob expansion) to discover files.
 - **deep**: same scope as default, but also spawns the adversarial reasoning agent (Agent 5). Use for thorough reviews. Slower and more costly.
 - **`$filename ...`**: scan the specified file(s) only.
 
@@ -19,26 +23,75 @@ You are the orchestrator of a parallelized smart contract security audit. Your j
 
 - `--file-output` (off by default): also write the report to a markdown file (path per `{resolved_path}/report-formatting.md`). Without this flag, output goes to the terminal only. Never write a report file unless the user explicitly passes `--file-output`.
 
+## Skill Path Resolution
+
+Before version check, resolve `skill_root` by taking the first existing path:
+
+1. `./.agents/skills/solidity-auditor`
+2. `$HOME/.agents/skills/solidity-auditor`
+3. `./solidity-auditor`
+4. `$HOME/.claude/commands/solidity-auditor`
+
+Set `{resolved_path}` to `${skill_root}/references`.
+
+If none exists, stop and ask the user to install the skill using the repo README install commands.
+
 ## Version Check
 
-After printing the banner, run two parallel tool calls: (a) Read the local `VERSION` file from the same directory as this skill, (b) Bash `curl -sf https://raw.githubusercontent.com/pashov/skills/main/solidity-auditor/VERSION`. If the remote fetch succeeds and the versions differ, print:
+After printing the banner, run local+remote checks in parallel when possible:
+
+1. Read local `${skill_root}/VERSION`
+2. Fetch remote `https://raw.githubusercontent.com/pashov/skills/main/solidity-auditor/VERSION`
+
+If remote succeeds and versions differ, print:
 
 > ⚠️ You are not using the latest version. Please upgrade for best security coverage. See https://github.com/pashov/skills#install--run
 
-Then continue normally. If the fetch fails (offline, timeout), skip silently.
+Then continue normally. If remote fetch fails (offline, timeout), skip silently.
 
 ## Orchestration
 
-**Turn 1 — Discover.** Print the banner, then in the same message make parallel tool calls: (a) Bash `find` for in-scope `.sol` files per mode selection, (b) Glob for `**/references/attack-vectors/attack-vectors-1.md` and extract the `references/` directory path (two levels up). Use this resolved path as `{resolved_path}` for all subsequent references.
+**Turn 1 — Discover.** Print the banner, parse mode/flags/filenames, and resolve in-scope Solidity files.
 
-**Turn 2 — Prepare.** In a single message, make three parallel tool calls: (a) Read `{resolved_path}/agents/vector-scan-agent.md`, (b) Read `{resolved_path}/report-formatting.md`, (c) Bash: create four per-agent bundle files (`/tmp/audit-agent-{1,2,3,4}-bundle.md`) in a **single command** — each concatenates **all** in-scope `.sol` files (with `### path` headers and fenced code blocks), then `{resolved_path}/judging.md`, then `{resolved_path}/report-formatting.md`, then `{resolved_path}/attack-vectors/attack-vectors-N.md`; print line counts. Every agent receives the full codebase — only the attack-vectors file differs per agent. Do NOT read or inline any file content into agent prompts — the bundle files replace that entirely.
+- For default/deep, discover files from current working directory using shell `find` with the exclude pattern.
+- For filename mode, use only user-provided file paths.
+- Normalize to unique existing `.sol` files.
+- If no in-scope files remain, stop and report that nothing matched scope.
 
-**Turn 3 — Spawn.** In a single message, spawn all agents as parallel foreground Agent tool calls (do NOT use `run_in_background`). Always spawn Agents 1–4. Only spawn Agent 5 when the mode is **DEEP**.
+**Turn 2 — Prepare.**
 
-- **Agents 1–4** (vector scanning) — spawn with `model: "sonnet"`. Each agent prompt must contain the full text of `vector-scan-agent.md` (read in Turn 2, paste into every prompt). After the instructions, add: `Your bundle file is /tmp/audit-agent-N-bundle.md (XXXX lines).` (substitute the real line count).
-- **Agent 5** (adversarial reasoning, DEEP only) — spawn with `model: "opus"`. Receives the in-scope `.sol` file paths and the instruction: your reference directory is `{resolved_path}`. Read `{resolved_path}/agents/adversarial-reasoning-agent.md` for your full instructions.
+- Read `{resolved_path}/agents/vector-scan-agent.md`.
+- Read `{resolved_path}/report-formatting.md`.
+- In one shell command, build four bundle files: `/tmp/audit-agent-1-bundle.md` ... `/tmp/audit-agent-4-bundle.md`.
+- Each bundle must concatenate, in order:
+  1. all in-scope `.sol` files with `### path` headers and fenced code blocks,
+  2. `{resolved_path}/judging.md`,
+  3. `{resolved_path}/report-formatting.md`,
+  4. `{resolved_path}/attack-vectors/attack-vectors-N.md` (N = 1..4).
+- Print each bundle line count.
+- Do not inline source code directly into agent prompts; bundle files are the sole code input for Agents 1–4.
 
-**Turn 4 — Report.** Merge all agent results: deduplicate by root cause (keep the higher-confidence version), sort by confidence highest-first, re-number sequentially, and insert the **Below Confidence Threshold** separator row. Print findings directly — do not re-draft or re-describe them. Use report-formatting.md (read in Turn 2) for the scope table and output structure. If `--file-output` is set, write the report to a file (path per report-formatting.md) and print the path.
+**Turn 3 — Spawn.**
+
+- Spawn Agents 1–4 in parallel foreground calls (no background jobs).
+- Each agent prompt must include the full text of `vector-scan-agent.md`, plus: `Your bundle file is /tmp/audit-agent-N-bundle.md (XXXX lines).`
+- Do not hard-pin runtime-specific model names; use default model selection for the current runtime.
+- Spawn Agent 5 only in **deep** mode:
+  - Provide in-scope `.sol` file paths and `{resolved_path}`.
+  - Instruct it to read `{resolved_path}/agents/adversarial-reasoning-agent.md` for full instructions.
+
+If sub-agent spawning is unavailable, run equivalent passes sequentially yourself using the same inputs and output contract.
+
+**Turn 4 — Report.**
+
+- Merge all agent results.
+- Deduplicate by root cause (keep higher-confidence version).
+- Sort by confidence descending.
+- Re-number sequentially.
+- Insert the **Below Confidence Threshold** separator row.
+- Print findings directly without re-drafting them.
+- Use `report-formatting.md` for full output structure and scope table.
+- If `--file-output` is set, write the report to file path per `report-formatting.md` and print the path.
 
 ## Banner
 

--- a/solidity-auditor/agents/openai.yaml
+++ b/solidity-auditor/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Solidity Auditor"
+  short_description: "Fast Solidity security review while you develop"
+
+policy:
+  allow_implicit_invocation: false

--- a/solidity-auditor/references/agents/vector-scan-agent.md
+++ b/solidity-auditor/references/agents/vector-scan-agent.md
@@ -8,7 +8,7 @@ You communicate results back ONLY through your final text response. Do not outpu
 
 ## Workflow
 
-1. Read your bundle file in **parallel 1000-line chunks** on your first turn. The line count is in your prompt — compute the offsets and issue all Read calls at once (e.g., for a 5000-line file: `Read(file, limit=1000)`, `Read(file, offset=1000, limit=1000)`, `Read(file, offset=2000, limit=1000)`, `Read(file, offset=3000, limit=1000)`, `Read(file, offset=4000, limit=1000)`). Do NOT read without a limit. These are your ONLY file reads — do NOT read any other file after this step.
+1. Read your bundle file in **parallel 1000-line chunks** on your first turn. The line count is in your prompt — compute offsets and issue bounded chunk reads (1000 lines each). If your runtime supports offset/limit reads, use that; otherwise use equivalent bounded line-range reads. Do NOT do an unbounded full-file read. These are your ONLY file reads — do NOT read any other file after this step.
 2. **Triage pass.** For each vector, classify into three tiers:
    - **Skip** — the named construct AND underlying concept are both absent (e.g., ERC721 vectors when there are no NFTs at all).
    - **Borderline** — the named construct is absent but the underlying vulnerability concept could manifest through a different mechanism in this codebase (e.g., "stale cached ERC20 balance" when the code caches cross-contract AMM reserves; "ERC777 reentrancy" when there are flash-swap callbacks).


### PR DESCRIPTION
## Summary
- add Codex install/update + invocation docs (`$solidity-auditor`, `/skills`)
- add optional Codex metadata (`agents/openai.yaml`) with `allow_implicit_invocation: false`
- make orchestrator + vector-agent prompts runtime-agnostic (remove Claude-only tool/model assumptions)
- add smoke CI workflow for skill structure/frontmatter/policy checks
- update contributing/PR/bug templates to Claude+Codex wording

## Testing
- local smoke checks passed:
  - required skill files exist
  - `SKILL.md` has `name` + `description`
  - `openai.yaml` has `allow_implicit_invocation: false`
  - no remaining `run_in_background`, hardcoded `sonnet|opus`, `Read(...)`, `Glob` assumptions in core prompts
