### PR TITLE
Move the reports finding table to bottom

### DIFF
--- a/solidity-auditor/references/report-formatting.md
+++ b/solidity-auditor/references/report-formatting.md
@@ -9,8 +9,6 @@ Save the report to `assets/findings/{project-name}-pashov-ai-audit-report-{times
 ````
 # 🔐 Security Review — <ContractName or repo name>
 
-> ⚠️ This review was performed by an AI assistant. AI analysis can never verify the complete absence of vulnerabilities and no guarantee of security is given. Team security reviews, bug bounty programs, and on-chain monitoring are strongly recommended. For a consultation regarding your projects' security, visit [https://www.pashov.com](https://www.pashov.com)
-
 ---
 
 ## Scope
@@ -25,16 +23,6 @@ Save the report to `assets/findings/{project-name}-pashov-ai-audit-report-{times
 
 ## Findings
 
-| # | Confidence | Title |
-|---|---|---|
-| 1 | [95] | <title> |
-| 2 | [82] | <title> |
-| | | **Below Confidence Threshold** |
-| 3 | [75] | <title> |
-| 4 | [60] | <title> |
-
----
-
 [95] **1. <Title>**
 
 `ContractName.functionName` · Confidence: 95
@@ -47,14 +35,43 @@ Save the report to `assets/findings/{project-name}-pashov-ai-audit-report-{times
 ```diff
 - vulnerable line(s)
 + fixed line(s)
-````
-
+```
 ---
 
 [82] **2. <Title>**
-...
 
+`ContractName.functionName` · Confidence: 82
+
+**Description**
+<The vulnerable code pattern and why it is exploitable, in 1 short sentence>
+
+**Fix**
+
+```diff
+- vulnerable line(s)
++ fixed line(s)
 ```
+---
+
+< ... all findings >
+
+---
+
+Findings List
+
+| # | Confidence | Title |
+|---|---|---|
+| 1 | [95] | <title> |
+| 2 | [82] | <title> |
+| | | **Below Confidence Threshold** |
+| 3 | [75] | <title> |
+| 4 | [60] | <title> |
+
+---
+
+> ⚠️ This review was performed by an AI assistant. AI analysis can never verify the complete absence of vulnerabilities and no guarantee of security is given. Team security reviews, bug bounty programs, and on-chain monitoring are strongly recommended. For a consultation regarding your projects' security, visit [https://www.pashov.com](https://www.pashov.com)
+
+````
 
 **Rules:** Follow the template above exactly. Sort findings by confidence (highest first). Findings below the threshold get a description but no **Fix** block. Draft findings directly in report format — do not re-generate.
-```
+


### PR DESCRIPTION
Move the reports finding to the bottom to visualize all issues without scrolling up in Claude Code.

# Pull Request

## Type of Change

- [ ] Improvement to an existing skill
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (describe below)

UI improvement for faster reading of all issues.

## Summary

Move the reports finding to the bottom to visualize all issues without scrolling up in Claude Code, in this way getting a clear view of all issues before scrolling up to see each individual finding.

## Changes

<!-- Bullet-point list of what changed -->
- Changed `references/report-formatting.md` to match the proposed format
-

## Testing

Describe how you tested the skill. Paste a representative input/output pair:

**Input:**
```
```

**Output:**
```
```

## Checklist

- [X] No API keys, tokens, or sensitive data included
- [] No fabricated examples — outputs must reflect real model responses
- [] Skill works with Claude Code CLI, VS Code, and Cursor
