### PR TITLE
Create ~/.claude/commands dir if doesn't exists during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Works with the **Claude Code CLI**, the **VS Code Claude extension**, and **Cursor**. Run the following in your terminal:
 
 ```bash
-git clone https://github.com/pashov/skills.git && cp -r skills/solidity-auditor ~/.claude/commands/solidity-auditor
+git clone https://github.com/pashov/skills.git && mkdir -p ~/.claude/commands && cp -r skills/solidity-auditor ~/.claude/commands/solidity-auditor
 ```
 
 The skill is then invocable as `/solidity-auditor`. See the [skill README](solidity-auditor/README.md) for usage.


### PR DESCRIPTION
Current "install" command breaks if you don't have ~/.claude/commands directory, which is not the default if you never installed any Claude commands.

Added `mkdir -p ~/.claude/commands` to create the directories if they don't exist (if exists, its no-op)

# Pull Request

## Type of Change

- [ ] Improvement to an existing skill
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (describe below)

DX improvement to install the skill without error if you dont have any commands dir.

## Summary

<!-- 2-4 sentences: what does this PR do and why? -->

## Changes

- Edited README.md install command to add the creation of `~/.claude/commands` if doesn't exists
-

## Testing

Describe how you tested the skill. Paste a representative input/output pair:

**Before**
cp error , target directory does not exist

**After**
install command works without errors if commands dir is missing

## Checklist

- [X] No API keys, tokens, or sensitive data included
- [ ] No fabricated examples — outputs must reflect real model responses
- [ ] Skill works with Claude Code CLI, VS Code, and Cursor
