### PR TITLE
docs: add Cursor install and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@
 
 ## Install & Run
 
-Works with the **Claude Code CLI**, the **VS Code Claude extension**, and **Cursor**. Run the following in your terminal:
+Works with the **Claude Code CLI**, the **VS Code Claude extension**, and **Cursor**.
+
+**Claude Code CLI:**
 
 ```bash
 git clone https://github.com/pashov/skills.git && mkdir -p ~/.claude/commands && cp -r skills/solidity-auditor ~/.claude/commands/solidity-auditor
+```
+
+**Cursor:**
+
+```bash
+git clone https://github.com/pashov/skills.git && mkdir -p ~/.cursor/skills && cp -r skills/solidity-auditor ~/.cursor/skills/solidity-auditor
 ```
 
 The skill is then invocable as `/solidity-auditor`. See the [skill README](solidity-auditor/README.md) for usage.
@@ -20,7 +28,11 @@ The skill is then invocable as `/solidity-auditor`. See the [skill README](solid
 **Update to latest:** `cd` into the cloned `skills` repo and run:
 
 ```bash
-git pull && cp -r solidity-auditor ~/.claude/commands/solidity-auditor
+git pull
+# Claude Code CLI:
+cp -r solidity-auditor ~/.claude/commands/solidity-auditor
+# Cursor:
+cp -r solidity-auditor ~/.cursor/skills/solidity-auditor
 ```
 
 ---


### PR DESCRIPTION
Add a Cursor-specific install path (~/.cursor/skills) and update commands so users can install the skill when using Cursor. Previously, only Claude Code CLI path was documented despite README claiming Cursor support.


# Pull Request

## Type of Change

- [ ] Improvement to an existing skill
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (describe below)

## Summary

Add Cursor-specific install and update instructions to the README. The README states the skill works with Cursor, but only the Claude Code CLI install path was documented. Cursor users load skills from `~/.cursor/skills/`, so this PR adds those instructions.

## Changes

- Add **Cursor** install block with `~/.cursor/skills` path
- Label existing install block as **Claude Code CLI**
- Update "Update to latest" section with both Claude Code CLI and Cursor copy commands (with comments)
- Preserve existing content; no behavioural changes to the skill

## Testing

**Input:** README install instructions

**Output:** Manually tested the Cursor install command:
```bash
git clone https://github.com/pashov/skills.git && mkdir -p ~/.cursor/skills && cp -r skills/solidity-auditor ~/.cursor/skills/solidity-auditor