### PR TITLE
feat: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "solidity-auditor",
+  "description": "Security audit skill for Solidity smart contracts",
+  "version": "1.0.0",
+  "author": {
+    "name": "Pashov Audit Group"
+  },
+  "repository": "https://github.com/pashov/skills",
+  "license": "MIT",
+  "keywords": ["solidity", "security", "audit", "smart-contracts"],
+  "skills": "./solidity-auditor"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,8 @@
 {
   "name": "pashov-skills",
   "description": "Solidity security skills from Pashov Audit Group — solidity-auditor and x-ray",
-  "version": "1.1.0",
-  "author": {
-    "name": "pashov"
-  },
+  "version": "3.0.0",
+  "author": "pashov",
   "repository": "https://github.com/pashov/skills",
   "license": "MIT",
   "keywords": ["solidity", "security", "audit", "smart-contracts", "x-ray"],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Security audit skill for Solidity smart contracts",
   "version": "1.0.0",
   "author": {
-    "name": "Pashov Audit Group"
+    "name": "pashov"
   },
   "repository": "https://github.com/pashov/skills",
   "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "solidity-auditor",
-  "description": "Security audit skill for Solidity smart contracts",
-  "version": "1.0.0",
+  "name": "pashov-skills",
+  "description": "Solidity security skills from Pashov Audit Group — solidity-auditor and x-ray",
+  "version": "1.1.0",
   "author": {
     "name": "pashov"
   },
   "repository": "https://github.com/pashov/skills",
   "license": "MIT",
-  "keywords": ["solidity", "security", "audit", "smart-contracts"],
-  "skills": "./solidity-auditor"
+  "keywords": ["solidity", "security", "audit", "smart-contracts", "x-ray"],
+  "skills": ["./solidity-auditor", "./x-ray"]
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ run the solidity auditor with all the different agents possible on *specified fi
 update skills to latest version
 ```
 
+**Claude Code plugin install:** `/plugin marketplace add pashov/skills` then `/plugin install pashov-skills`
+
 ---
 
 ## Skills


### PR DESCRIPTION
## Summary

Adds a `.claude-plugin/plugin.json` manifest so this repo can be installed as a Claude Code plugin, covering both `solidity-auditor` and `x-ray`. Adds a one-line install note to the README. No files moved or restructured.

## Benefits

- **Native install** — `/plugin install` via Claude Code's built-in plugin system, the user can choose it as an alternative to the custom installer.
- **Standard lifecycle** — the user can choose to enable/disable/update/uninstall through `/plugin` commands.
- **Multi-platform** — works across Claude Code CLI, desktop, and IDE extensions.
- **Additive** — 12-line manifest + one README line; existing install flow untouched.

## Changes

- **New file**: `.claude-plugin/plugin.json`
- **Modified**: `README.md` (one line)

## Test plan

- [ ] Install via existing flow (`Install https://github.com/pashov/skills/ ...`) still works
- [ ] `/plugin marketplace add pashov/skills` + `/plugin install pashov-skills` installs both skills
- [ ] `solidity-auditor` and `x-ray` skills load and trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)