### PR TITLE
solidity-auditor: Make it discover prior audits and calibrate severity

### DIFF
--- a/solidity-auditor/SKILL.md
+++ b/solidity-auditor/SKILL.md
@@ -27,8 +27,25 @@ c. ToolSearch `select:Agent`
 d. Read the local `VERSION` file from the same directory as this skill
 e. Bash `curl -sf https://raw.githubusercontent.com/pashov/skills/main/solidity-auditor/VERSION`
 f. Bash `mktemp -d /tmp/audit-XXXXXX` → store as `{bundle_dir}`
+g. **Prior-audit discovery** — Bash `find` for prior audit reports in the project, excluding `lib/`, `node_modules/`, `.git/`. Search common locations and patterns:
+
+```
+find . -type f \( -iname "*.pdf" -o -iname "*.md" \) \
+  \( -ipath "*/audit*/*" -o -ipath "*/reports/*" -o -ipath "*/findings/*" -o -ipath "*/security/*" \
+     -o -iname "*audit*" -o -iname "*report*" -o -iname "*findings*" -o -iname "*review*" \) \
+  -not -path "./lib/*" -not -path "./node_modules/*" -not -path "./.git/*" 2>/dev/null
+```
+
+Store the result as `{prior_audits}`. If non-empty, store the list and proceed; if any are PDFs, attempt `pdftotext -layout` (best-effort; skip silently if `pdftotext` isn't installed).
 
 If the remote VERSION fetch succeeds and differs from local, print `⚠️ You are not using the latest version. Please upgrade for best security coverage. See https://github.com/pashov/skills`. If it fails, skip silently.
+
+**If `{prior_audits}` is non-empty**, after the discovery tool calls return: in a single message, Read each prior audit report (or its extracted `.txt` if PDF). Extract per report:
+- Each finding's title + severity + status (Fixed / Acknowledged / Mitigated / Open)
+- The team's response text where present (e.g., "Sky: Acknowledged. We interpreted ...")
+- The auditor's final verdict (e.g., "Cantina Managed: Acknowledged.")
+
+Build a `{bundle_dir}/prior-audits.md` with one section per report containing this extracted index. This file will be referenced in Turn 4 gate-evaluation; it does NOT need to be inlined into agent bundles. Print a one-line summary: `Prior audits found: N (Cantina, ChainSecurity, ...) — see {bundle_dir}/prior-audits.md`.
 
 **Turn 2 — Prepare.** In one message, make parallel tool calls: (a) Read `{resolved_path}/report-formatting.md`, (b) Read `{resolved_path}/judging.md`.
 
@@ -67,6 +84,14 @@ Read the bundle fully before producing findings.
 2. **Gate evaluation.** Run each deduplicated finding through the four gates in `judging.md` (do not skip or reorder). Evaluate each finding exactly once — do not revisit after verdict.
 
    **Single-pass protocol:** evaluate every relevant code path ONCE in fixed order (constructor → setters → swap functions → mint → burn → liquidate). One-line verdict per path: `BLOCKS`, `ALLOWS`, `IRRELEVANT`, or `UNCERTAIN`. Commit after all paths — do not re-examine. `UNCERTAIN` = `ALLOWS`.
+
+   **Prior-audit calibration (only if `{bundle_dir}/prior-audits.md` exists):** before assigning final severity, cross-reference each finding against `prior-audits.md`. For matches:
+   - **Same issue, status = Fixed** → verify the fix is actually present on the current branch (`main`, `master`, or `dev`). If present → REJECTED. If absent → keep at original severity and tag `[regression-of: <auditor> <ref>]`.
+   - **Same issue, status = Acknowledged / Mitigated / Open** → still in code by definition; keep the finding but downgrade by one severity level and tag `[also-flagged-by: <auditor> <severity>]`. The team explicitly chose not to fix; re-reporting at original severity ignores their adjudication.
+   - **Same issue described as "trust assumption" or "documented design"** → demote to LEAD or NOTE; cite the trust-model line verbatim. Do not re-elevate to FINDING unless you can show a concrete spec text or invariant the team's documented assumption violates.
+   - **Novel issue not in any prior audit** → keep at full severity.
+
+   This calibration step exists because items already adjudicated by paid auditors and accepted-as-acknowledged carry strong Bayesian evidence of bounded severity. Re-reporting them at original severity without weighing the prior adjudication is a known false-positive pattern.
 
 3. **Lead promotion & rejection guardrails.**
    - Promote LEAD → FINDING (confidence 75) if: complete exploit chain traced in source, OR `[agents: 2+]` demoted (not rejected) the same issue.


### PR DESCRIPTION
  ## Summary

  Makes `solidity-auditor` aware of prior audit reports so it doesn't
  re-elevate already-adjudicated issues at fresh-finding severity.

  ## Changes

  - **Turn 1** — find audit reports under `audits/`, `reports/`,
    `findings/`, `security/`; extract title + severity + status into
    `{bundle_dir}/prior-audits.md`. Falls back if `pdftotext` is missing.
  - **Turn 4** — calibrate each finding against `prior-audits.md`:
    Fixed → REJECT (or `[regression-of:...]` if not on current branch);
    Acknowledged/Mitigated/Open → downgrade one level + `[also-flagged-by:...]`;
    trust-assumption → demote to LEAD/NOTE.

  ## Why

  Prior auditor adjudication is strong Bayesian evidence of bounded
  severity; re-scoring it as novel is a known false-positive pattern.
  Conversely, a stale "Fixed" label that no longer holds is itself a
  finding worth flagging.

  ## Compatibility

  No-op when audits or pdftotext are absent. No agent-bundle changes.