### PR TITLE
docs: add npx skills install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ update skills to latest version
 
 ---
 
+## Install via `npx skills`
+
+[`skills`](https://github.com/vercel-labs/skills) is a CLI that installs agent skills straight from GitHub — no clone, no config.
+
+```bash
+# Interactive: pick which skills to install into the current project
+npx skills add pashov/skills
+
+# See what's available first
+npx skills add pashov/skills --list
+
+# Install specific skills
+npx skills add pashov/skills --skill x-ray --skill solidity-auditor
+
+# Install everything, non-interactively, into Claude Code globally (CI-friendly)
+npx skills add pashov/skills -g -a claude-code -y
+```
+
+`-a` targets a specific agent (`claude-code`, `cursor`, `codex`, `opencode`, …). Update later with `npx skills update`.
+
+---
+
 ## Skills
 
 | Skill                                 | Description                                                                     |


### PR DESCRIPTION
Adds a section documenting installation via the [`skills`](https://github.com/vercel-labs/skills) CLI.

`npx skills add` discovers any `SKILL.md` in a repo tree (via the GitHub Trees API), so this repo's top-level skill folders (`x-ray/`, `solidity-auditor/`, `fizz/`) are already installable — this just documents the command alongside the existing natural-language install prompts.

```bash
npx skills add pashov/skills            # interactive picker
npx skills add pashov/skills --list     # list available
npx skills add pashov/skills -g -a claude-code -y  # all, global, CI-friendly
```

Docs only — no skill content changed.