### PR TITLE
docs: add npx skills install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ update skills to latest version
 
 ---
 
+## Install via `npx skills`
+
+[`skills`](https://github.com/vercel-labs/skills) is a CLI that installs agent skills straight from GitHub — no clone, no config.
+
+```bash
+# Interactive: pick which skills to install into the current project
+npx skills add pashov/skills
+
+# See what's available first
+npx skills add pashov/skills --list
+
+# Install specific skills
+npx skills add pashov/skills --skill x-ray --skill solidity-auditor
+
+# Install everything, non-interactively, into Claude Code globally (CI-friendly)
+npx skills add pashov/skills -g -a claude-code -y
+```
+
+`-a` targets a specific agent (`claude-code`, `cursor`, `codex`, `opencode`, …). Update later with `npx skills update`.
+
+---
+
 ## Skills
 
 | Skill                                 | Description                                                                     |


### PR DESCRIPTION
# Pull Request

## Type of Change

- [ ] Improvement to an existing skill
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (describe below)

## Summary

Adds an "Install via `npx skills`" section to the README documenting installation through the [`skills`](https://github.com/vercel-labs/skills) CLI. The CLI discovers any `SKILL.md` in a repo tree via the GitHub Trees API, so this repo is already installable that way — this PR just documents the command alongside the existing natural-language install prompts. Docs only; no skill content or behavior changed.

## Changes

- Added a new `## Install via npx skills` section to `README.md` (placed after the existing "Install, Run & Update Prompts" block).
- Documented the interactive picker, `--list`, per-skill `--skill`, and a non-interactive global form (`-g -a claude-code -y`), plus `npx skills update`.

## Testing

Ran the list command against the repo to confirm all skills are discovered correctly.

**Input:**
```
npx skills add pashov/skills --list
```

**Output:**
```
◇  Source: https://github.com/pashov/skills.git
◇  Repository cloned
◇  Found 3 skills
◇  Available Skills

   fizz
     Generate Echidna/Medusa-compatible Solidity fuzz suites from Foundry or Hardhat projects. ...

   solidity-auditor
     Security audit of Solidity code while you develop. Trigger on "audit", "check this contract", ...

   x-ray
     Generates an x-ray.md pre-audit report covering overview, enhanced threat model ...

└  Use --skill <name> to install specific skills
```

## Checklist

- [x] No API keys, tokens, or sensitive data included
- [x] No fabricated examples — outputs must reflect real model responses
- [ ] Skill works with Claude Code CLI, VS Code, and Cursor <!-- N/A: docs-only change, no skill logic modified -->
