### PR TITLE
skills: add dynamic workflow dispatch for multi-agent steps

### DIFF
--- a/fizz/SKILL.md
+++ b/fizz/SKILL.md
@@ -59,6 +59,32 @@ Resolve once at the start of the run and reuse it for every spawn below:
 
 Every subsequent spawn instruction below references `{AGENT_MODEL}` — substitute the resolved value when making the actual tool call. Do NOT mix tiers within a single run.
 
+## Subagent Orchestration
+
+**Workflows are Claude Code only.** Every other runtime — Codex, Gemini, Cursor's native agent, Copilot, Windsurf — runs the Agent path, which is this skill's original behaviour and stays fully supported. Never emulate, shim, or hand-roll a workflow on a runtime that does not have the tool.
+
+Resolve `{ORCHESTRATION}` once, silently, at the start of the run — no user-facing output, no question, and no extra line in Step 0's resolved-values output. It only decides *how* subagents are dispatched; `{AGENT_MODEL}` still decides which model they run on, on every path. If detection needs a `ToolSearch`, batch it into the same call that fetches `AskUserQuestion` in Step 0 (`select:AskUserQuestion,Workflow`) so Step 0's output discipline is preserved.
+
+- `{ORCHESTRATION} = "workflow"` **only if** the `Workflow` tool is actually available in your runtime — its schema is loaded, or `ToolSearch` with `select:Workflow` returns it. Positive detection is required: a successful schema fetch, nothing weaker. Never infer availability from the model you are running, the presence of the `Agent` tool, or the fact that this section mentions workflows.
+- Otherwise → `{ORCHESTRATION} = "agents"`: parallel `general-purpose` Agent spawns, exactly as before.
+
+If a `Workflow` call fails at runtime for any reason (tool not found, invalid script, rejected), do not retry it — fall back to the Agent path for that step and continue. A workflow is a dispatch optimisation, never a hard dependency.
+
+Which steps this affects:
+
+| Step | Agents | `{ORCHESTRATION} = "workflow"` | `{ORCHESTRATION} = "agents"` |
+|---|---|---|---|
+| 3, Attempt 4 — Protocol Analyzer | 1 | Agent tool (unchanged) | Agent tool |
+| 9b + 9c — 5 discovery agents → Synthesizer | 6 | one `Workflow` call | 5 parallel Agent spawns, then 1 |
+| 9d — 2 implementers | 2 | one `Workflow` call | 2 parallel Agent spawns |
+| 11 — Report Writer | 1 | Agent tool (unchanged) | Agent tool |
+
+Single-agent steps stay on the Agent tool on every path — a workflow around one agent adds a layer without adding parallelism or determinism.
+
+**Opt-in**: this skill instructing you to call `Workflow` *is* the required user opt-in for multi-agent orchestration. Do not ask the user to confirm it, and do not fall back to the Agent path because the user did not say "use a workflow".
+
+**Everything else is unchanged.** The workflow paths dispatch the same prompts, built from the same agent files with the same placeholder substitutions, and write the same files. Every `{MODE} = "guided"` checkpoint still happens in the parent agent, between workflow calls — never inside a script.
+
 ## Step 0: Print Banner
 
 At the start of every skill run, **first** print this ASCII banner once before any other output — including any selection prompt:
@@ -422,9 +448,9 @@ Extract from the codebase:
 - **CONVERSION_FUNCTIONS**: grep for `convertTo*`, `preview*`, `toAssets`, `toShares`, or any function mapping between two unit systems
 - **ACCESS_CONTROL**: grep for `onlyOwner`, `onlyAdmin`, `onlyRole`, `require(msg.sender`, custom role modifiers
 
-### Step 9b: Spawn 5 Discovery Agents in Parallel
+### Step 9b: Discovery Agents
 
-**CRITICAL**: All 5 agents MUST be spawned in a SINGLE message (one tool call per agent, all in the same response).
+The 5 discovery agents:
 
 | Agent | File | Discovery Approach |
 |-------|------|-------------------|
@@ -434,17 +460,41 @@ Extract from the codebase:
 | 4. Adversarial Profit Maximizer | `{SKILL_PATH}/agents/invariant-discovery/adversarial-profit-maximizer.md` | Attacker thinking — DoS, value extraction, edge states |
 | 5. Protocol-Type Specialist | `{SKILL_PATH}/agents/invariant-discovery/protocol-type-specialist.md` | Auto-detect type, apply domain templates (vault/lending/AMM/etc.) |
 
-Read each agent file, replace `{INVARIANT_CONTEXT}` and `{FILE_PATHS}` with actual values, spawn as `general-purpose` agent with `model: "{AGENT_MODEL}"`.
+For every path: read each agent file and replace `{INVARIANT_CONTEXT}` and `{FILE_PATHS}` with actual values to build that agent's prompt. The 5 prompts are identical across both dispatch paths.
+
+**If `{ORCHESTRATION} = "workflow"`**: do not spawn anything here. Steps 9b and 9c run as a single `Workflow` call — see Step 9c below.
+
+**If `{ORCHESTRATION} = "agents"`**: spawn all 5 as `general-purpose` agents with `model: "{AGENT_MODEL}"`. **CRITICAL**: all 5 MUST be spawned in a SINGLE message (one tool call per agent, all in the same response).
 
 ### Step 9c: Synthesize Property Plan
 
-After all 5 agents return, read the Synthesizer agent file:
+The Synthesizer agent file:
 
 | Agent | File |
 |-------|------|
 | 6. Synthesizer | `{SKILL_PATH}/agents/invariant-discovery/synthesizer.md` |
 
-Replace `{AGENT_OUTPUTS}` with the outputs from agents 1-5, `{META_DIR}` with the actual `{META_DIR}` path, `{PROJECT_ROOT}` with the actual `{PROJECT_ROOT}` path, and `{SUITE_DIR}` with the actual `{SUITE_DIR}` path, then spawn as `general-purpose` agent with `model: "{AGENT_MODEL}"`.
+Read it and replace `{META_DIR}` with the actual `{META_DIR}` path, `{PROJECT_ROOT}` with the actual `{PROJECT_ROOT}` path, and `{SUITE_DIR}` with the actual `{SUITE_DIR}` path. `{AGENT_OUTPUTS}` is filled with the combined output of agents 1–5.
+
+**If `{ORCHESTRATION} = "agents"`**: after all 5 discovery agents return, substitute `{AGENT_OUTPUTS}` with their outputs and spawn the Synthesizer as a `general-purpose` agent with `model: "{AGENT_MODEL}"`.
+
+**If `{ORCHESTRATION} = "workflow"`**: issue ONE `Workflow` call covering Steps 9b and 9c. Pass `scriptPath` (see below) and `args` as a JSON object — an actual object, never a JSON-encoded string — with:
+
+- `agentModel` — the resolved `{AGENT_MODEL}` (`"sonnet"` or `"opus"`)
+- `discovery` — 5 entries `{label, prompt}`, where `label` is the agent's short name (`conservation-auditor`, `roundtrip-rounding-analyst`, `state-transition-mapper`, `adversarial-profit-maximizer`, `protocol-type-specialist`) and `prompt` is that agent's fully substituted prompt from Step 9b
+- `synthesizer` — the Synthesizer prompt with `{META_DIR}` / `{PROJECT_ROOT}` / `{SUITE_DIR}` already substituted and `{AGENT_OUTPUTS}` left as a literal placeholder
+
+The script ships with this skill at `{SKILL_PATH}/workflows/invariant-discovery.js` — pass it to `Workflow` as `scriptPath`. Do NOT paste it inline as `script`; the file on disk is the single source of truth.
+
+Notes on this script, all load-bearing:
+
+- The `typeof args === 'string'` guard is REQUIRED, not defensive padding. Some runtimes hand the script `args` already JSON-encoded. Destructuring a string does not throw — every field silently becomes `undefined`, and the run dies on `discovery.map` with `undefined is not an object` before a single agent spawns. Keep the guard on both scripts in this skill.
+- `parallel` is a barrier on purpose. The Synthesizer's whole job is cross-agent merge and dedup, so it genuinely needs all 5 outputs at once — this is the case where a barrier beats a pipeline.
+- `model: agentModel` is set on every `agent()` call, so `{AGENT_MODEL}` (including `--max` / `--opus`) reaches the discovery agents and the Synthesizer alike. Never mix tiers within a run.
+- `{AGENT_OUTPUTS}` substitution uses `split`/`join`, not `String.replace`, so `$&`-style sequences in agent output can't corrupt the Synthesizer prompt.
+- A `null` entry in `found` means that discovery agent was skipped or died after retries. The Synthesizer sees `(agent returned nothing)` for it; report that lens as missing rather than treating its silence as "no invariants found".
+- The workflow ends at the Synthesizer. The guided-mode `PROPERTIES.md` review below happens in the parent agent, after the workflow returns.
+
 The Synthesizer merges, deduplicates, prioritizes, and writes BOTH:
 - `{PROJECT_ROOT}/{META_DIR}/property-plan.md` — implementation tables with stable Spec IDs (`GL-NN`, `SP-NN`)
 - `{PROJECT_ROOT}/PROPERTIES.md` — English-language spec with `[ ]` checkboxes, one entry per property, identified by the same Spec IDs. This is the artifact that the `/fizz-convert` command and the implementers in Step 9d operate on.
@@ -453,7 +503,7 @@ Each property carries a **Guarantee** tag set at generation time — `SHOULD-HOL
 
 Print a summary: "Generated X properties (N HIGH, N MEDIUM, N LOW; P SHOULD-HOLD, Q EXPLORATORY)" with a brief list of the top properties by priority.
 
-If `{MODE} = "guided"`, pause here: tell the user the file path (`{PROJECT_ROOT}/PROPERTIES.md`), summarise what the Synthesizer produced, and ask *"Review `PROPERTIES.md` and edit freely — rename, add, remove, or reword properties. Keep the Spec IDs (`GL-NN` / `SP-NN`) on entries you want implemented, and leave `[ ]` checkboxes unchanged. Reply 'proceed' when done, or 'regenerate' to re-run the Synthesizer with additional guidance."* If they reply `regenerate`, ask what to change, then re-spawn the Synthesizer (Step 9c) with the extra guidance appended to its input. If they reply `proceed`, continue to Step 9d. In `{MODE} = "automatic"`, skip the pause and proceed directly.
+If `{MODE} = "guided"`, pause here: tell the user the file path (`{PROJECT_ROOT}/PROPERTIES.md`), summarise what the Synthesizer produced, and ask *"Review `PROPERTIES.md` and edit freely — rename, add, remove, or reword properties. Keep the Spec IDs (`GL-NN` / `SP-NN`) on entries you want implemented, and leave `[ ]` checkboxes unchanged. Reply 'proceed' when done, or 'regenerate' to re-run the Synthesizer with additional guidance."* If they reply `regenerate`, ask what to change, then re-run the Synthesizer with the extra guidance appended to its input — as a single `general-purpose` Agent call with `model: "{AGENT_MODEL}"` on both paths, reusing the discovery output you already have (on the workflow path, the `discovery` field of the returned object). Do NOT re-run the 5 discovery agents. If they reply `proceed`, continue to Step 9d. In `{MODE} = "automatic"`, skip the pause and proceed directly.
 
 ### Step 9d: Implement Properties (2 Parallel Agents)
 
@@ -464,7 +514,15 @@ Read each agent file:
 | 7A. Global Property Implementer | `{SKILL_PATH}/agents/implementers/global-property-implementer.md` | Ghosts in Base.sol, State in Snapshots.sol, global properties in Properties.sol, harness contracts if needed |
 | 7B. Specific Property Implementer | `{SKILL_PATH}/agents/implementers/specific-property-implementer.md` | Specific properties in Properties.sol, handler wiring (ghost updates + snapshot calls + property assertions) |
 
-Replace `{META_DIR}` with the actual `{META_DIR}` path, `{SKILL_PATH}` with the actual `{SKILL_PATH}` path, `{PROJECT_ROOT}` with the actual `{PROJECT_ROOT}` path, and `{SUITE_DIR}` with the actual `{SUITE_DIR}` path, then spawn both as `general-purpose` agents with `model: "{AGENT_MODEL}"` in parallel.
+For every path: replace `{META_DIR}` with the actual `{META_DIR}` path, `{SKILL_PATH}` with the actual `{SKILL_PATH}` path, `{PROJECT_ROOT}` with the actual `{PROJECT_ROOT}` path, and `{SUITE_DIR}` with the actual `{SUITE_DIR}` path to build each implementer's prompt. Both prompts are identical across dispatch paths.
+
+**If `{ORCHESTRATION} = "agents"`**: spawn both as `general-purpose` agents with `model: "{AGENT_MODEL}"`, in parallel, in a single message.
+
+**If `{ORCHESTRATION} = "workflow"`**: issue ONE `Workflow` call with `scriptPath` (see below) and `args` as a JSON object — an actual object, never a JSON-encoded string — with `agentModel` (the resolved `{AGENT_MODEL}`) and `implementers` — 2 entries `{label, prompt}` with labels `global-property-implementer` and `specific-property-implementer`.
+
+The script ships with this skill at `{SKILL_PATH}/workflows/property-implementers.js` — pass it to `Workflow` as `scriptPath`. Do NOT paste it inline as `script`; the file on disk is the single source of truth.
+
+Do NOT add `isolation: 'worktree'` here. Both implementers must edit the same working tree — the specific implementer wires handlers against ghosts and snapshot fields the global implementer adds, and both flip checkboxes in the same `PROPERTIES.md`. Isolating them would split those edits across throwaway worktrees. This is the same shared-tree arrangement the Agent path has always used; Step 9e's build is what catches any collision.
 
 Both implementers MUST flip `[ ]` → `[x]` in `{PROJECT_ROOT}/PROPERTIES.md` for each property they actually implement (matching by Spec ID `GL-NN` / `SP-NN`). Properties left as TODO stubs stay `[ ]` so `/fizz-convert` can pick them up later.
 

--- a/fizz/workflows/invariant-discovery.js
+++ b/fizz/workflows/invariant-discovery.js
@@ -1,0 +1,39 @@
+// Steps 9b+9c: 5 invariant-discovery agents in parallel, then the Synthesizer.
+// Called via Workflow({scriptPath: <this file>, args: {...}}). Claude Code only.
+//
+// args:
+//   agentModel  string - resolved {AGENT_MODEL} ("sonnet" default, "opus" with --max)
+//   discovery   array  - 5x {label:string, prompt:string} fully substituted
+//   synthesizer string - Synthesizer prompt, {AGENT_OUTPUTS} left as a literal placeholder
+//
+// returns: {discovery: string, plan: string}
+//   The guided-mode PROPERTIES.md review happens in the parent agent after this
+//   returns - workflows take no mid-run user input.
+
+export const meta = {
+  name: 'fizz-invariant-discovery',
+  description: 'Run 5 invariant-discovery agents in parallel, then synthesize the property plan',
+  phases: [
+    { title: 'Discover', detail: '5 discovery agents, one lens each' },
+    { title: 'Synthesize', detail: 'merge, dedupe, prioritize, write PROPERTIES.md' },
+  ],
+}
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+const { agentModel, discovery, synthesizer } = input
+
+phase('Discover')
+const found = await parallel(discovery.map((d) => () =>
+  agent(d.prompt, { label: d.label, phase: 'Discover', model: agentModel })))
+
+const outputs = found
+  .map((r, i) => '### ' + discovery[i].label + '\n\n' + (r || '(agent returned nothing)'))
+  .join('\n\n---\n\n')
+
+phase('Synthesize')
+const plan = await agent(
+  synthesizer.split('{AGENT_OUTPUTS}').join(outputs),
+  { label: 'synthesizer', phase: 'Synthesize', model: agentModel },
+)
+
+return { discovery: outputs, plan }

--- a/fizz/workflows/property-implementers.js
+++ b/fizz/workflows/property-implementers.js
@@ -1,0 +1,28 @@
+// Step 9d: the 2 property implementers in parallel, sharing one working tree.
+// Called via Workflow({scriptPath: <this file>, args: {...}}). Claude Code only.
+//
+// args:
+//   agentModel   string - resolved {AGENT_MODEL}
+//   implementers array  - 2x {label:string, prompt:string}, labels
+//                         "global-property-implementer" / "specific-property-implementer"
+//
+// Do NOT add isolation:'worktree' - the specific implementer wires handlers against
+// ghosts the global one adds, and both edit PROPERTIES.md. Step 9e's build catches
+// any collision.
+
+export const meta = {
+  name: 'fizz-property-implementers',
+  description: 'Implement global and specific properties into the fuzz harness in parallel',
+  phases: [{ title: 'Implement', detail: 'global + specific property implementers' }],
+}
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+const { agentModel, implementers } = input
+
+phase('Implement')
+const results = await parallel(implementers.map((i) => () =>
+  agent(i.prompt, { label: i.label, phase: 'Implement', model: agentModel })))
+
+return results
+  .map((r, i) => '### ' + implementers[i].label + '\n\n' + (r || '(agent returned nothing)'))
+  .join('\n\n---\n\n')

--- a/solidity-auditor/SKILL.md
+++ b/solidity-auditor/SKILL.md
@@ -22,8 +22,8 @@ You are the orchestrator of a parallelized smart contract security audit.
 **Turn 1 — Discover.** Print the banner, then make these parallel tool calls in one message:
 
 a. Bash `find` for in-scope `.sol` files per mode selection
-b. Glob for `**/references/hacking-agents/shared-rules.md` — extract the `references/` directory (two levels up) as `{resolved_path}`
-c. ToolSearch `select:Agent`
+b. Glob for `**/references/hacking-agents/shared-rules.md` — extract the `references/` directory (two levels up) as `{resolved_path}`, and its parent (the directory holding this `SKILL.md`) as `{skill_dir}`
+c. ToolSearch `select:Agent,Workflow`
 d. Read the local `VERSION` file from the same directory as this skill
 e. Bash `curl -sf https://raw.githubusercontent.com/pashov/skills/main/solidity-auditor/VERSION`
 f. Bash `mktemp -d ./.audit-XXXXXX` → store as `{bundle_dir}`
@@ -66,6 +66,15 @@ On Claude Code:
    ```
 3. Store the runner's choice as `{agent_model}`. If no answer, default to the orchestrator's own model.
 
+**Turn 1c — Resolve `{orchestration}` (Claude Code only).** No user-facing output, no question. Decide how the 12 agents will be dispatched, based on what Turn 1's ToolSearch (step c) returned:
+
+- `{orchestration} = "workflow"` **only if** the `Workflow` tool schema actually came back — a positive schema fetch, nothing weaker. This is the Claude Code path: one deterministic fan-out with a live progress tree instead of 12 loose background tasks. Never infer availability from the model you are running, from the presence of the `Agent` tool, or from the fact that this skill mentions workflows.
+- Otherwise (Codex, Gemini, Cursor's native agent, Copilot, Windsurf, or any runtime without `Workflow`) → `{orchestration} = "agents"`. Never emulate, shim, or hand-roll a workflow where the tool does not exist.
+
+`{orchestration}` selects between Turn 3a-W and Turn 3a-A. Nothing else in this skill changes — same 12 bundles, same 12 prompts, same Turn 4.
+
+If the Turn 3a-W `Workflow` call fails for any reason (tool not found, invalid script, rejected), do not retry it — fall back to Turn 3a-A and continue. The workflow is a dispatch optimisation, never a hard dependency.
+
 **Turn 2 — Prepare.** In one message, make parallel tool calls: (a) Read `{resolved_path}/report-formatting.md`, (b) Read `{resolved_path}/judging.md`.
 
 Then build all bundles in a single Bash command using `cat` (not shell variables or heredocs):
@@ -92,18 +101,57 @@ Each bundle = source.md + SOP + specialty + shared-rules. Agents read the bundle
 
 Print line counts for every bundle and `source.md`. Do NOT inline source code into the Agent call prompt itself.
 
-**Turn 3a — Spawn all 12 agents.** In one message, spawn all 12 agents as **parallel BACKGROUND Agent calls** (`run_in_background=true`). If Turn 1b set `{agent_model}`, pass `model={agent_model}` on every Agent call. If `{agent_model}` is unset (Turn 1b skipped — Codex, Gemini, others), omit the `model` parameter entirely — do NOT substitute any default. The orchestrator will receive a notification when each agent completes — do NOT poll or sleep. Single phase, no later spawns. Proceed to Turn 3b only after all 12 have notified completion.
+**Turn 3a — Dispatch all 12 agents.** Exactly one of the two paths below runs, selected by `{orchestration}` from Turn 1c. Both dispatch the same 12 prompts against the same 12 bundles and produce the same raw material for Turn 4 — only the transport differs.
 
 Agents 1–9 use the **single-specialty prompt** (Turn 3a-i). Agents 10–12 use the **gap-hunter prompt** (Turn 3a-ii).
 
+**Turn 3a-W — Workflow path (`{orchestration} = "workflow"`).** Issue ONE `Workflow` call. This skill instructing you to call `Workflow` is the required opt-in — do not ask the user to confirm multi-agent orchestration, and do not fall back to Turn 3a-A because the tool "wasn't requested".
+
+Pass `scriptPath` (see below) and `args` as a JSON object — an actual object, never a JSON-encoded string — with:
+
+- `bundleDir` — `{bundle_dir}` from Turn 1
+- `agentModel` — `{agent_model}` from Turn 1b, or `null` if Turn 1b was skipped
+- `bundles` — 12 entries `{n, specialty, lines}`, where `specialty` is the agent's specialty file basename without extension (`math-precision`, `access-control`, `economic-security`, `execution-trace`, `invariant`, `periphery`, `first-principles`, `asymmetry`, `boundary`, `numerical-gap`, `trust-gap`, `flow-gap` for agents 1–12 in order) and `lines` is that bundle's real line count from Turn 2
+- `singleSpecialtyPrompt` — the Turn 3a-i template, with `{BUNDLE_PATH}` and `{LINES}` left as literal placeholders
+- `gapHunterPrompt` — the Turn 3a-ii template, same placeholders left literal
+
+The script ships with this skill at `{skill_dir}/workflows/audit-12.js` — pass it to `Workflow` as `scriptPath`. Do NOT paste it inline as `script`; the file on disk is the single source of truth.
+
+Notes on this script, all load-bearing. Each one exists because a real run failed without it:
+
+- **`schema` is what makes this deterministic.** It forces each agent through a StructuredOutput tool and returns a *validated object*, so Turn 4 reads `findings[]` / `leads[]` fields directly. Never regex free text for `FINDING |` lines: an agent whose final message is truncated silently loses findings, and the loss is invisible because the surviving text still parses. A real run lost 2 FINDINGs exactly this way — the agent's return value began mid-sentence at 4,714 chars while its transcript held 12,319. A schema removes the whole failure class.
+- **The `markers` field is required, not decoration.** `shared-rules.md` says the orchestrator greps agent output for `[Feynman:]` / `[Socratic:]` / `[Inversion:]` markers and verifies their counts. A schema replaces the free-text stream those markers lived in, so the counts must be carried explicitly or the protocol check silently becomes unenforceable.
+- **The `typeof args === 'string'` guard is REQUIRED, not padding.** The workflows docs state `args` arrives as structured data, but a real run received it JSON-encoded. Destructuring a string does not throw — every field silently becomes `undefined` and the run dies on `bundles.map` with `undefined is not an object` before a single agent spawns. Keep the guard on every script in this skill.
+- **Every agent resolves to an `{ok}` record, never a bare `null`.** `parallel` converts a thrown thunk to `null`, and `{...null}` spreads to `{}` — which would look like a successful agent that found nothing. The two-layer normalisation (`.then` for a null return, `settled` for a thrown thunk) makes a dead agent structurally distinguishable from a clean one.
+- `coverage.failed` is returned so Turn 4 can name missing agents instead of silently reporting reduced coverage as a clean result.
+- `parallel` is a barrier on purpose. Dedup in Turn 4 needs all 12 outputs at once, so there is nothing to pipeline.
+- `agentModel` is applied per `agent()` call via `opts.model`, so Turn 1b's selection reaches every one of the 12. When it is `null` the key is omitted entirely and each agent inherits the session model — same rule as Turn 3a-A.
+- Placeholder substitution uses `split`/`join`, not `String.replace`, so `$&`-style sequences inside a bundle path can't corrupt the prompt.
+
+**Prompt suffix (workflow path only).** Append this to both templates before passing them in, so agents know where the markers go:
+
+```
+Return your result through the StructuredOutput tool matching the provided
+schema. Put the literal [Feynman:] / [Socratic:] / [Inversion:] working text
+in markers.transcript, and their counts in markers.feynman / .socratic /
+.inversion. Every field required by shared-rules.md maps to a schema field —
+findings[] for FINDINGs, leads[] for LEADs. Do not omit group_key.
+```
+
+If a schema-validated agent exhausts its retries the runtime reports `error_max_structured_output_retries`; that agent lands in `coverage.failed` and must be named in Turn 4, not treated as finding-free.
+
+**Turn 3a-A — Agent path (`{orchestration} = "agents"`).** In one message, spawn all 12 agents as **parallel BACKGROUND Agent calls** (`run_in_background=true`). If Turn 1b set `{agent_model}`, pass `model={agent_model}` on every Agent call. If `{agent_model}` is unset (Turn 1b skipped — Codex, Gemini, others), omit the `model` parameter entirely — do NOT substitute any default. The orchestrator will receive a notification when each agent completes — do NOT poll or sleep. Single phase, no later spawns.
+
 **Turn 3a-i — Single-specialty prompt template (agents 1–9, substitute real values):**
+
+On the Agent path, substitute the real bundle path and line count directly. On the Workflow path, leave `{BUNDLE_PATH}` and `{LINES}` as literal placeholders — the script fills them in.
 
 ```
 You are an attacker. Your specialty, mindset, source, and output rules
 are in your bundle. Read it fully before producing findings.
 
 Read first:
-- {bundle_dir}/agent-N-bundle.md (XXXX lines) — source + SOP + specialty + shared rules.
+- {BUNDLE_PATH} ({LINES} lines) — source + SOP + specialty + shared rules.
 
 The bundle contains all in-scope source. Do NOT re-read in-scope files
 for the initial scan. Use Read/Grep only for cross-file searches or
@@ -126,12 +174,14 @@ Output format: see shared-rules.md inside your bundle.
 
 **Turn 3a-ii — Gap-hunter prompt template (agents 10–12, substitute real values):**
 
+Same placeholder rule as Turn 3a-i.
+
 ```
 You are an attacker. Your gap-hunter specialty, mindset, source, and
 output rules are in your bundle. Read it fully before producing findings.
 
 Read first:
-- {bundle_dir}/agent-N-bundle.md (XXXX lines) — source + SOP + gap-hunter specialty + shared rules.
+- {BUNDLE_PATH} ({LINES} lines) — source + SOP + gap-hunter specialty + shared rules.
 
 The bundle contains all in-scope source. Do NOT re-read in-scope files
 for the initial scan. Use Read/Grep only for cross-file searches or
@@ -154,11 +204,14 @@ Output format: see shared-rules.md inside your bundle (gap-hunter-specific
 output fields are in your specialty file).
 ```
 
-**Turn 3b — Wait for all 12 agents to complete.** Once every one of the 12 spawned agents has notified completion, proceed to Turn 4. Do NOT proceed to dedup until every agent has finished — let them run to natural completion. Do NOT poll or sleep; act only on completion notifications.
+**Turn 3b — Wait for the 12 agents to complete.** Do NOT proceed to dedup until every agent has finished — let them run to natural completion. Do NOT poll or sleep; act only on completion notifications.
+
+- `{orchestration} = "workflow"`: wait for the single workflow task notification. Its return value is a JSON object `{coverage, markers, findings[], leads[]}` — already validated against the schema, one flat array of findings and one of leads, each item tagged with the `agent` and `specialty` that produced it. Feed those arrays straight into Turn 4; do NOT re-parse text. Check `coverage.failed` first: any agent listed there contributed nothing and must be named in the Turn 4 completeness line. The task notification truncates long values for display — that truncation is cosmetic, the workflow's actual return value is intact, and the full per-agent record is in `journal.jsonl` in the transcript directory if you need it.
+- `{orchestration} = "agents"`: wait until every one of the 12 spawned agents has notified completion.
 
 **Turn 4 — Deduplicate, validate & output.** Single-pass: deduplicate all agent results, gate-evaluate, and produce the final report in one turn. Do NOT print an intermediate dedup list — go straight to the report.
 
-1. **Dedup.** Parse every FINDING and LEAD from the 12 agents. Group by `group_key` (Contract | function | bug-class). Exact-match first; merge synonymous bug_class within same (Contract, function). Keep best per group, number sequentially, annotate `[agents: N]`.
+1. **Dedup.** Collect every FINDING and LEAD from the 12 agents. On the Turn 3a-W path they arrive as the workflow's `findings[]` and `leads[]` arrays — structured, pre-tagged with `agent`/`specialty`, no parsing required. On the Turn 3a-A path, parse them out of the 12 agent notifications. If any agent produced no output at all (crashed, was skipped, or exhausted its structured-output retries), name it in the completeness line at the end of this step; a missing agent is reduced coverage, not a clean result. Group by `group_key` (Contract | function | bug-class). Exact-match first; merge synonymous bug_class within same (Contract, function). Keep best per group, number sequentially, annotate `[agents: N]`.
 
    **MANDATORY — Wide-description (group_key).** Merged group with distinct mechanisms (different `fix:`, code-level cause, or attack path) MUST list every mechanism. No dropping. Same function can have multiple coexisting bugs at the same group_key — all MUST appear.
 

--- a/solidity-auditor/workflows/audit-12.js
+++ b/solidity-auditor/workflows/audit-12.js
@@ -1,0 +1,95 @@
+// Dispatches the 12 attacker-specialty audit agents. Called by SKILL.md Turn 3a-W
+// via Workflow({scriptPath: <this file>, args: {...}}). Claude Code only.
+//
+// args:
+//   bundleDir             string  - the mktemp'd {bundle_dir} holding agent-N-bundle.md
+//   agentModel            string  - "opus"|"sonnet"|"haiku" from Turn 1b, or null to
+//                                   inherit the session model
+//   bundles               array   - 12x {n:1..12, specialty:string, lines:number}
+//                                   agents 1-9 get singleSpecialtyPrompt, 10-12 gapHunterPrompt
+//   singleSpecialtyPrompt string  - Turn 3a-i template, {BUNDLE_PATH}/{LINES} left literal
+//   gapHunterPrompt       string  - Turn 3a-ii template, same placeholders
+//
+// returns: {coverage:{total,ok,failed[]}, markers[], findings[], leads[]}
+//   findings/leads are schema-validated and flattened, each tagged {agent, specialty}.
+//   Turn 4 groups by group_key directly - never regex this output.
+
+export const meta = {
+  name: 'solidity-auditor-12',
+  description: 'Run the 12 attacker-specialty audit agents over prebuilt bundles',
+  phases: [{ title: 'Attack', detail: '12 specialty agents, one bundle each' }],
+}
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+const { bundleDir, agentModel, bundles, singleSpecialtyPrompt, gapHunterPrompt } = input
+
+const S = { type: 'string' }
+const AUDIT_SCHEMA = {
+  type: 'object',
+  required: ['markers', 'findings', 'leads'],
+  properties: {
+    markers: {
+      type: 'object',
+      required: ['feynman', 'socratic', 'inversion'],
+      properties: {
+        feynman: { type: 'number' },
+        socratic: { type: 'number' },
+        inversion: { type: 'number' },
+        transcript: S,
+      },
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['contract', 'function', 'bug_class', 'group_key', 'path', 'proof', 'description', 'fix'],
+        properties: {
+          contract: S, function: S, bug_class: S, group_key: S,
+          path: S, proof: S, description: S, fix: S,
+        },
+      },
+    },
+    leads: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['contract', 'function', 'bug_class', 'group_key', 'code_smells', 'description'],
+        properties: {
+          contract: S, function: S, bug_class: S, group_key: S,
+          code_smells: S, description: S,
+        },
+      },
+    },
+  },
+}
+
+phase('Attack')
+
+const results = await parallel(bundles.map((b) => () => {
+  const template = b.n <= 9 ? singleSpecialtyPrompt : gapHunterPrompt
+  const prompt = template
+    .split('{BUNDLE_PATH}').join(bundleDir + '/agent-' + b.n + '-bundle.md')
+    .split('{LINES}').join(String(b.lines))
+  const opts = {
+    label: 'agent-' + b.n + ':' + b.specialty,
+    phase: 'Attack',
+    schema: AUDIT_SCHEMA,
+  }
+  if (agentModel) opts.model = agentModel
+  return agent(prompt, opts).then((r) =>
+    r ? { ok: true, ...b, ...r } : { ok: false, ...b, error: 'agent returned null' })
+}))
+
+const settled = results.map((r, i) => r || { ok: false, ...bundles[i], error: 'agent threw or was skipped' })
+const ok = settled.filter((r) => r.ok)
+
+return {
+  coverage: {
+    total: bundles.length,
+    ok: ok.length,
+    failed: settled.filter((r) => !r.ok).map((r) => r.n + ':' + r.specialty + ' (' + r.error + ')'),
+  },
+  markers: ok.map((r) => ({ agent: r.n, specialty: r.specialty, ...r.markers })),
+  findings: ok.flatMap((r) => (r.findings || []).map((f) => ({ agent: r.n, specialty: r.specialty, ...f }))),
+  leads: ok.flatMap((r) => (r.leads || []).map((l) => ({ agent: r.n, specialty: r.specialty, ...l }))),
+}

--- a/x-ray/SKILL.md
+++ b/x-ray/SKILL.md
@@ -9,6 +9,21 @@ Generate an `x-ray/` folder at the project root containing all output files. Pip
 
 `$SKILL_DIR` = the directory containing this SKILL.md file. Resolve it from the path you loaded this skill from (e.g. if this file is at `/path/to/x-ray/SKILL.md`, then `$SKILL_DIR` = `/path/to/x-ray`).
 
+## Subagent orchestration
+
+This skill spawns subagents in exactly two places, both Path B only: the Step 1 spec-doc reader and the Step 2 Tier 2 source readers. How they are dispatched depends on `$ORCHESTRATION`, resolved once, silently, before Step 1 — no user-facing output, no question.
+
+**Workflows are Claude Code only.** Every other runtime — Codex, Gemini, Cursor's native agent, Copilot, Windsurf — runs the Agent path, which is this skill's original behaviour and stays fully supported.
+
+- `$ORCHESTRATION = "workflow"` **only if** the `Workflow` tool is actually available — its schema is loaded, or `ToolSearch` with `select:Workflow` returns it. Positive detection is required: a successful schema fetch, nothing weaker. Never infer availability from the model you are running, from the presence of the `Agent` tool, or from the fact that this section mentions workflows. Never emulate or hand-roll a workflow where the tool does not exist.
+- Otherwise → `$ORCHESTRATION = "agents"`: parallel `general-purpose` Agent spawns, exactly as before.
+
+Readers run on `model: "sonnet"` on both paths — they extract facts, they do not analyze. This skill has no model selector; if you change that default, change it in one place and let both paths read it.
+
+If a `Workflow` call fails at runtime for any reason, do not retry it — fall back to the Agent path and continue. It is a dispatch optimisation, never a hard dependency.
+
+Path A never spawns anything on either path. Do not introduce a workflow where the current instructions say "direct reads — no subagent needed".
+
 ## Progress tracking (MANDATORY)
 
 Before doing anything else, call TodoWrite with these 3 todos (all `pending`):
@@ -71,7 +86,7 @@ The JSON has 7 sections: `repo_shape`, `fix_candidates`, `dangerous_area_changes
 **4. Spec/whitepaper detection** (1 Glob: `**/{whitepaper,spec,design,protocol,architecture,overview,README}*.{pdf,md}` excluding `node_modules/`, `lib/`, `x-ray/`, `test/`). Skip user-facing docs (tutorials, API refs, changelogs, contribution guides). Then apply size-aware handling:
 
 - **Path A (≤5 docs, each ≤300 lines):** Include them as Read calls in Step 2's parallel message. Direct reads — no subagent needed.
-- **Path B (>5 docs OR any doc >300 lines):** Launch a single subagent (`model: "sonnet"`) that reads ALL doc files and returns a structured extraction (max 200 lines). Subagent prompt:
+- **Path B (>5 docs OR any doc >300 lines):** Build a single **doc reader** (`model: "sonnet"`) that reads ALL doc files and returns a structured extraction (max 200 lines). Reader prompt:
   ```
   Read each doc file listed below. Extract ONLY security-relevant information into this format:
   Files: [list of doc file paths]
@@ -92,7 +107,9 @@ The JSON has 7 sections: `repo_shape`, `fix_candidates`, `dangerous_area_changes
 
   Rules: Quote the source doc for each claim. Omit sections with no relevant content. Max 200 lines total.
   ```
-  Include this subagent in Step 1's parallel message. Its output feeds Step 3 report writing.
+  Its output feeds Step 3 report writing. Where it is dispatched depends on `$ORCHESTRATION`:
+  - `"agents"`: spawn it as a subagent inside Step 1's parallel message, as before.
+  - `"workflow"`: do not spawn it here. Carry the built prompt forward — it becomes one entry in the reader list dispatched by the single `Workflow` call in Step 2 (see "Path B dispatch"). Its output is not needed before Step 3, so the one-message delay costs nothing.
 
 For both paths, extract only: doc-stated global invariants, actor definitions, cross-system flows, trust assumptions, economic properties, key design decisions. Tag all spec-derived claims in the report with `(per spec)` so auditors know what is code-verified vs spec-stated. Doc-stated global invariants feed Step 2g's NatSpec routing step — they route to §2 / §3 / §4 of `invariants.md` by shape, NOT to §1 (Enforced Guards).
 
@@ -100,7 +117,7 @@ ALL calls (coverage, git analysis, reference reads, spec glob) MUST appear in th
 
 ## Step 2: Read Source Files + Entry Point Scan (SINGLE message, ALL tool calls parallel)
 
-CRITICAL: Every tool call — Bash, Agent, Read, Grep — MUST be issued in ONE message so they run concurrently. This includes source file reads, the entry point grep scan, and any spec doc detected in Step 1 (they are all independent).
+CRITICAL: Every tool call — Bash, Agent, Workflow, Read, Grep — MUST be issued in ONE message so they run concurrently. This includes source file reads, the entry point grep scan, and any spec doc detected in Step 1 (they are all independent). On the workflow path the readers are one `Workflow` call, which still belongs in that same message.
 
 ### Scope Filtering
 - Skip interfaces: `interfaces/` dirs or filenames `I` + uppercase letter
@@ -116,7 +133,7 @@ One Read call per file. Do NOT read README, docs, or foundry.toml (already read 
 
 **Tier 1 — Small files (≤120 lines):** Batch into single Bash `cat` call.
 
-**Tier 2 — Large files (>120 lines):** Group by subsystem. Launch **one subagent per subsystem** (`model: "sonnet"`, up to 5, max ~10 files each). Subagent prompt:
+**Tier 2 — Large files (>120 lines):** Group by subsystem. Build **one reader per subsystem** (`model: "sonnet"`, up to 5, max ~10 files each), then dispatch them per "Path B dispatch" below. Reader prompt:
 ```
 Read each file listed below and return a structured summary. Do NOT analyze — just extract facts.
 Files: [list of file paths]
@@ -144,6 +161,24 @@ For EACH file, return this exact format:
   - `functionName()` — NONE — calls `ContractName.method()`
 ```
 
+### Path B dispatch
+
+Collect every Path B reader that applies to this run into one list: the Step 1 doc reader (if Step 1 took Path B) plus each Tier 2 subsystem reader. Prompts are identical on both dispatch paths — only the transport differs. Let `N` be the list length.
+
+**If `$ORCHESTRATION = "agents"`, or `N == 1`**: spawn each reader as a `general-purpose` Agent with `model: "sonnet"`, in this step's single parallel message, as before. A workflow around one agent adds a layer without adding parallelism, so `N == 1` always takes this path.
+
+**If `$ORCHESTRATION = "workflow"` and `N >= 2`**: issue ONE `Workflow` call, in this step's single parallel message alongside the Tier 1 `cat` and both grep scans. This skill instructing you to call `Workflow` is the required opt-in — do not ask the user to confirm multi-agent orchestration. Pass `scriptPath` (see below) and `args` as a JSON object — an actual object, never a JSON-encoded string — with `readers` — one entry `{label, prompt}` per reader, `label` being the subsystem name (or `spec-docs` for the Step 1 doc reader).
+
+The script ships with this skill at `$SKILL_DIR/workflows/path-b-readers.js` — pass it to `Workflow` as `scriptPath`. Do NOT paste it inline as `script`; the file on disk is the single source of truth.
+
+Notes on this script, all load-bearing:
+
+- The `typeof args === 'string'` guard is REQUIRED, not defensive padding. Some runtimes hand the script `args` already JSON-encoded. Destructuring a string does not throw — every field silently becomes `undefined`, and the run dies on `readers.map` with `undefined is not an object` before a single reader spawns.
+- `parallel` is a barrier on purpose. Step 2b onwards needs the full extraction set at once, and readers are pure fact extraction with nothing to pipeline into.
+- `model: 'sonnet'` is fixed here to match the Agent path. Readers extract facts; they do not analyze.
+- A `null` entry means that reader was skipped or died after retries. Do NOT treat a missing subsystem as "nothing found" — its files are simply unread, so either re-dispatch that one reader or read them directly before Step 2b.
+- The workflow returns in the background. Step 2b and everything downstream still gate on its output, and the grep scan below remains the hard source of truth for entry points regardless.
+
 ### Entry Point Grep Scan (INCLUDED in the same parallel message as source reads)
 
 Launch these two **Bash** calls in the SAME message as the source file reads above — they are independent and can run concurrently. Commands use **only POSIX ERE + POSIX character classes** (no `-P` / PCRE, no GNU-only escapes like `\s` `\w` `\b`), so they work identically on GNU grep (Linux/WSL), BSD grep (macOS default `/usr/bin/grep`, FreeBSD), and ripgrep:
@@ -168,7 +203,7 @@ Combine results from both. The multiline grep is critical — Solidity functions
 - `[[:space:]]`, `[[:alnum:]_]` → POSIX character classes, supported by all above
 - `--include='*.sol'` → GNU + macOS BSD grep + ripgrep. Not supported by busybox grep (niche; Alpine minimal); if the skill ever needs to run there, replace `--include='*.sol' [src]/` with `$(find [src]/ -name '*.sol')` passed as arguments.
 
-ALL tool calls (source reads/Bash/subagents, BOTH grep scans) MUST be in ONE message.
+ALL tool calls (source reads/Bash/subagents or the readers `Workflow` call, BOTH grep scans) MUST be in ONE message.
 
 Do NOT read test files or documentation files.
 

--- a/x-ray/workflows/path-b-readers.js
+++ b/x-ray/workflows/path-b-readers.js
@@ -1,0 +1,26 @@
+// Path B fact extraction: one reader per source subsystem, plus the Step 1 spec-doc
+// reader. Called via Workflow({scriptPath: <this file>, args: {...}}). Claude Code only.
+// Only used when 2+ readers apply; a lone reader goes through the Agent tool instead.
+//
+// args:
+//   readers array - {label:string, prompt:string}; label is the subsystem name,
+//                   or "spec-docs" for the Step 1 doc reader
+//
+// Readers are pinned to sonnet: they extract facts, they do not analyze.
+
+export const meta = {
+  name: 'xray-path-b-readers',
+  description: 'Read source subsystems and spec docs in parallel, returning structured fact extractions',
+  phases: [{ title: 'Read', detail: 'one reader per subsystem / doc set' }],
+}
+
+const input = typeof args === 'string' ? JSON.parse(args) : args
+const { readers } = input
+
+phase('Read')
+const out = await parallel(readers.map((r) => () =>
+  agent(r.prompt, { label: r.label, phase: 'Read', model: 'sonnet' })))
+
+return out
+  .map((r, i) => '### READER — ' + readers[i].label + '\n\n' + (r || '(reader returned nothing)'))
+  .join('\n\n---\n\n')


### PR DESCRIPTION
## Type of Change

- [x] Improvement to an existing skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

## Summary

Adds a Claude Code-only [dynamic workflow](https://code.claude.com/docs/en/workflows) dispatch path to the three skills that spawn subagents, alongside the existing Agent path. Where a skill currently fans out N parallel `Agent` calls, it can now issue one `Workflow` call that runs the same prompts as a scripted fan-out with a live progress tree, resumable within the session.

The runtime is detected by positively fetching the `Workflow` tool schema. Codex, Gemini, Cursor's native agent, Copilot and Windsurf all keep the current behaviour unchanged, and a `Workflow` call that fails for any reason falls back to the Agent path rather than retrying — the workflow is a dispatch optimisation, never a hard dependency.

Each skill's existing model selector feeds the workflow: solidity-auditor's `AskUserQuestion` choice and fizz's `{AGENT_MODEL}` (including `--max`/`--opus`) are applied per `agent()` call via `opts.model`.

## Changes

- **solidity-auditor** — Turn 1c resolves `{orchestration}`; Turn 3a splits into 3a-W (one `Workflow` call, 12 agents) and 3a-A (the existing 12 background `Agent` calls). Prompt templates gain `{BUNDLE_PATH}`/`{LINES}` placeholders so both paths share one template.
- **fizz** — new "Subagent Orchestration" section resolving `{ORCHESTRATION}`. Steps 9b+9c become one workflow (5 discovery agents → Synthesizer), Step 9d another (2 implementers). The Protocol Analyzer and Report Writer stay on the Agent tool — a workflow around one agent adds a layer without adding parallelism.
- **x-ray** — Path B readers (Step 1 spec-doc reader + Step 2 Tier 2 subsystem readers) dispatch as one workflow, but only when 2+ readers apply; a lone reader still goes through the Agent tool.
- Workflow scripts ship as `.js` files under each skill's `workflows/` directory and are passed as `scriptPath`, so there is one source of truth rather than a copy embedded in markdown. Each carries its args contract as a header comment.
- Guided-mode checkpoints stay in the parent agent between workflow calls, since [workflows take no mid-run user input](https://code.claude.com/docs/en/workflows#behavior-and-limits).
- `VERSION` files untouched (bumped by CI on merge).

Two behaviours surfaced by running the auditor end-to-end and are now handled in the scripts:

- **`args` can arrive JSON-encoded.** The docs state args reaches the script as structured data; a real run received a string. Destructuring a string does not throw — every field silently becomes `undefined` and the run dies on `bundles.map` before spawning anything. Guarded in all four scripts.
- **An agent's free-text return can be truncated,** silently dropping findings while the surviving text still parses. solidity-auditor's agents now return schema-validated objects, so Turn 4 reads `findings[]`/`leads[]` fields directly instead of regex-scanning for `FINDING |` lines. Marker counts are carried in a required `markers` field so `shared-rules.md`'s protocol check stays enforceable, and dead agents surface in `coverage.failed` instead of looking like clean runs.

## Testing

Ran solidity-auditor end-to-end on a real Foundry repo (23 in-scope `.sol`, 6,469 lines) through the workflow path on Claude Code, with the model selector set to opus.

**Input:**
```
Turn 1   23 in-scope .sol files; VERSION 3 == upstream 3
Turn 1b  AskUserQuestion -> {agent_model} = opus
Turn 1c  Workflow schema present -> {orchestration} = workflow
Turn 2   source.md 6561 lines; 12 bundles, 6717-6769 lines each
Turn 3a-W  one Workflow call, 12 agents, model: "opus" on every one
```

**Output:**
```
status     completed
agents     12 done, 0 error, 0 skipped, 0 empty
tokens     625,814 subagent tokens
tool_uses  36
duration   797,706 ms (13m18s)
result     40 FINDINGs, 44 LEADs
           -> 22 unique (contract, function) finding groups
           7 of 12 agents independently converged on
           TokenLocker.uniswapV3SwapCallback
```

Honest scope of what that run proves: it exercised the **inline** template. The `scriptPath` refactor and the schema-validated return in this PR were added *in response to* that run's two failures and have been verified against a stubbed harness, not a second live audit — driven with string-encoded args, one null-returning agent and one throwing agent, asserting `10 ok / 12`, both failures named in `coverage.failed`, 12 agents dispatched with the 9/3 single-vs-gap-hunter split, `model` on every call, and `$&`-containing paths surviving substitution. All four scripts pass `node --check`.

Not verified: a live audit through the schema path, and the fizz/x-ray workflow paths, which follow the same shape but were not run end-to-end.

## Checklist

- [x] No API keys, tokens, or sensitive data included
- [x] No fabricated examples — outputs must reflect real model responses
- [x] Skill works with Claude Code CLI, VS Code, and Cursor
