### PR TITLE
fix: plateau detection parsing + raise default grace period

### DIFF
--- a/fizz/scripts/run_medusa.js
+++ b/fizz/scripts/run_medusa.js
@@ -17,7 +17,7 @@
  *   --meta-dir            fizz_data
  *   --min-seconds         60
  *   --max-stagnant-lines  5
- *   --grace-seconds       5
+ *   --grace-seconds       60
  *   --timeout             300
  *   --coverage-mode       false (plateau detection disabled; coverage report path printed but never auto-opened)
  *   --logs                false (live log viewer + coverage report print their URLs, but the browser is not auto-opened)
@@ -39,7 +39,14 @@ const projectRoot = path.resolve(args[0]);
 let metaRelDir = 'fizz_data';
 let minSeconds = 60;
 let maxStagnantLines = 5;
-let graceSeconds = 5;
+// Medusa's graceful shutdown is dominated by AnalyzeSourceCoverage, which walks every
+// contract in the whole compilation (not just the fuzzed ones) and is therefore driven by
+// codebase size, not corpus size. Measured SIGINT -> exit on real projects: prb-math
+// (107 sources) 1.8s, Balancer reclamm (220 sources, 134 contracts) 29.9s. The old 5s
+// default killed medusa mid-analysis on anything of normal audit size, which loses the
+// coverage report entirely; a kill during the report write instead truncates it, because
+// WriteHTMLReport/WriteLCOVReport write straight to the final path with no temp+rename.
+let graceSeconds = 60;
 let timeoutSeconds = 300;
 let logFilePath = null;
 let coverageMode = false;
@@ -166,17 +173,36 @@ startLogViewer('Medusa', '#22c55e', { open: openLogs }).then(({ viewerState, app
     let stderrBuffer = '';
     let childExited = false;
 
-    function parseStatusLine(line) {
+    // Medusa colourises its status lines unless `logging.noColor` is set, which puts an
+    // escape sequence between every label and its value. Strip them before matching, but
+    // only for parsing - the mirrored output keeps its colour.
+    const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+    // Medusa's formatDuration prints `42s` under a minute, `6m32s` under an hour and
+    // `1h06m32s` beyond that. Matching only the `%ds` form meant elapsed stopped parsing
+    // at 60s, which is also the default --min-seconds, so the plateau check could never
+    // reach its own threshold.
+    function parseElapsedSeconds(line) {
+        const match = line.match(/elapsed:\s*(?:(\d+)h)?(?:(\d+)m)?(\d+)s/i);
+        if (!match) return null;
+
+        const [, hours, minutes, seconds] = match;
+        return Number(hours || 0) * 3600 + Number(minutes || 0) * 60 + Number(seconds);
+    }
+
+    function parseStatusLine(rawLine) {
         if (!coverageMode) return;
 
-        const elapsedMatch = line.match(/elapsed:\s*([\d,]+)s/i);
-        const branchesMatch = line.match(/branches hit:\s*([\d,]+)/i);
+        const line = rawLine.replace(ANSI_PATTERN, '');
 
-        if (!elapsedMatch || !branchesMatch) return;
+        const elapsedSeconds = parseElapsedSeconds(line);
+        // `branches hit:` on medusa <= 1.4.1, renamed to `branches:` in 1.5.0.
+        const branchesMatch = line.match(/branches(?:\s+hit)?:\s*([\d,]+)/i);
+
+        if (elapsedSeconds === null || !branchesMatch) return;
 
         sawBranchesMetric = true;
 
-        const elapsedSeconds = Number(elapsedMatch[1].replace(/,/g, ''));
         const branchesHit = Number(branchesMatch[1].replace(/,/g, ''));
         if (!Number.isFinite(elapsedSeconds) || !Number.isFinite(branchesHit)) return;
 
@@ -291,7 +317,7 @@ startLogViewer('Medusa', '#22c55e', { open: openLogs }).then(({ viewerState, app
         }
 
         if (coverageMode && !sawBranchesMetric) {
-            writeStderr(`${TAG} No \`branches hit\` progress lines were observed; Medusa was not auto-stopped by plateau detection.\n`);
+            writeStderr(`${TAG} No branch-coverage progress lines were observed; Medusa was not auto-stopped by plateau detection.\n`);
         }
 
         const lcovPath = path.join(projectRoot, metaRelDir, 'corpus_medusa', 'coverage', 'lcov.info');


### PR DESCRIPTION
Three independent bugs made --coverage-mode's plateau detection non-functional on every medusa version:

1. Status lines are ANSI-colored unless `logging.noColor` is set; the regex never stripped escape codes, so it could never match colored output.
2. medusa >=1.5.0 renamed the `branches hit:` metric to `branches:`.
3. `formatDuration` switches from `%ds` to `%dm%ds` at 60s, which is also the default `--min-seconds` — so elapsed parsing broke exactly when the plateau check first becomes eligible to fire.

Because plateau detection never actually triggered, the 5s default `--grace-seconds` was never exercised in practice. Fixing the parsing without also raising it would turn a currently-dead code path into active data loss: medusa's graceful shutdown (worker unwind → corpus flush → `AnalyzeSourceCoverage` → report write) is driven by compiled codebase size, not corpus size, and measured 1.06–1.79s on small projects but 29.87s on a 220-source/134-contract real repo (Balancer reclamm). `AnalyzeSourceCoverage` alone was 80–97% of that time across every project tested.

A SIGKILL landing before `AnalyzeSourceCoverage` finishes means no report is written at all, and `run_medusa.js` then silently displays the previous run's stale `lcov.info` as the current summary. A SIGKILL during the write is worse: `WriteHTMLReport`/`WriteLCOVReport` write directly to the final path with no temp+rename, so the file is left truncated — reproduced deterministically with a phase-triggered kill (59.4MB → 18.4MB, no closing `</html>`, cut off mid-`<tr>`).

Raises the default to 60s, in line with measured real-repo shutdown times, and fixes the three parsing bugs so the feature is reachable at all.