### PR TITLE
Add best-practices and latest-docs skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,10 @@ A library of Claude AI skills. Each skill is a focused, self-contained capabilit
 ## Structure
 
 ```
-solidity-auditor/ # Security review of Solidity changes while you develop
-CLAUDE.md            # This file (read by Claude Code)
+solidity-auditor/  # Security review of Solidity changes while you develop
+best-practices/    # Research and apply current best practices for a stack
+latest-docs/       # Check a library's current docs against assumed/old API
+CLAUDE.md          # This file (read by Claude Code)
 ```
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ Works with the **Claude Code CLI**, the **VS Code Claude extension**, and **Curs
 **Claude Code CLI:**
 
 ```bash
-git clone https://github.com/pashov/skills.git && mkdir -p ~/.claude/commands && cp -r skills/solidity-auditor ~/.claude/commands/solidity-auditor
+git clone https://github.com/pashov/skills.git && mkdir -p ~/.claude/commands && cp -r skills/{solidity-auditor,best-practices,latest-docs} ~/.claude/commands/
 ```
 
 **Cursor:**
 
 ```bash
-git clone https://github.com/pashov/skills.git && mkdir -p ~/.cursor/skills && cp -r skills/solidity-auditor ~/.cursor/skills/solidity-auditor
+git clone https://github.com/pashov/skills.git && mkdir -p ~/.cursor/skills && cp -r skills/{solidity-auditor,best-practices,latest-docs} ~/.cursor/skills/
 ```
 
-The skill is then invocable as `/solidity-auditor`. See the [skill README](solidity-auditor/README.md) for usage.
+Each skill is then invocable as `/solidity-auditor`, `/best-practices`, or `/latest-docs`. See the [skill README](solidity-auditor/README.md) for solidity-auditor usage.
 
 **Update to latest:** `cd` into the cloned `skills` repo and run:
 
 ```bash
 git pull
 # Claude Code CLI:
-cp -r solidity-auditor ~/.claude/commands/solidity-auditor
+cp -r solidity-auditor best-practices latest-docs ~/.claude/commands/
 # Cursor:
-cp -r solidity-auditor ~/.cursor/skills/solidity-auditor
+cp -r solidity-auditor best-practices latest-docs ~/.cursor/skills/
 ```
 
 ---
@@ -42,6 +42,8 @@ cp -r solidity-auditor ~/.cursor/skills/solidity-auditor
 | Skill                                 | Description                                                                     |
 | ------------------------------------- | ------------------------------------------------------------------------------- |
 | [solidity-auditor](solidity-auditor/) | Fast (typically <5 min) security feedback on Solidity changes while you develop |
+| [best-practices](best-practices/)     | Research current best practices/idioms for a stack, answer or review code against them |
+| [latest-docs](latest-docs/)           | Check a library's current docs against what training data or code assumes      |
 
 ---
 

--- a/best-practices/SKILL.md
+++ b/best-practices/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: best-practices
+description: Research current best practices and idiomatic patterns for a language, framework, or library from official docs and style guides, then either answer a best-practices question directly or review given code against those patterns. Use when the user asks "what's idiomatic here", "is this best practice", "review this for best practices", or wants code checked against current stack conventions.
+---
+
+# Best Practices & Idiomatic Review
+
+## Quick start
+
+State the stack — language, framework, or library. Point at files or a
+diff if you want a review. Without a target, this skill answers the
+question directly.
+
+Examples: "What's the idiomatic way to handle errors in Go?" or "Review
+`src/api/users.ts` against current Express best practices."
+
+## Workflow
+
+1. **Identify the stack.** Take it from the request. If unstated and a
+   target file exists, infer it from the file extension or the
+   project's manifest (`package.json`, `Cargo.toml`, `go.mod`, and so
+   on). Confirm with the user if it stays ambiguous.
+2. **Research from primary sources.** Search and fetch the maintainer's
+   own docs and style guide first — the language's own guide (Effective
+   Go, PEP 8, the Rust API Guidelines), a framework's official docs, or
+   a library's own README and CHANGELOG. Treat blog posts and forum
+   answers as secondary. Use them only to confirm a primary source,
+   never as the sole basis for a claim.
+3. **Answer or review.**
+   - No target: answer the question directly and cite the sources
+     checked.
+   - Target given: read the files. Compare each relevant pattern
+     against what you found. List concrete deviations as `file:line` —
+     what the code does, what the idiom is, and the fix. Skip anything
+     already idiomatic. Do not rewrite the whole file.
+4. **Cite sources.** Trace every claim to a source fetched during this
+   run. Never state a "best practice" from memory alone. List the URLs
+   checked at the end.
+
+## Rules
+
+- Ground every claim in a source read this session. Do not rely on
+  training-data memory of a style guide.
+- Prefer the official convention over a trendy one when the docs
+  disagree with common practice.
+- Flag when a "best practice" is contested or version-dependent instead
+  of stating one answer as universal.

--- a/latest-docs/SKILL.md
+++ b/latest-docs/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: latest-docs
+description: Fetch a library, framework, or API's current official documentation and changelog, then report what changed from what training data or existing code assumes — renamed or removed APIs, new required parameters, deprecations. Use when the user names a specific library or framework and asks to check the latest docs, verify the current API, or confirm code isn't calling a deprecated or renamed method.
+---
+
+# Check Latest Docs
+
+## Quick start
+
+Name the library, and its version if known. Add the code or API calls
+to verify if you want them checked. This skill fetches the library's
+current docs and reports the delta.
+
+Examples: "Check the latest docs for Zod v4, did the API change?" or
+"Verify `src/db.ts` still matches Prisma's current client API."
+
+## Workflow
+
+1. **Identify the library and version.** Take it from the request. If
+   no version is given and a manifest or lockfile is available, read
+   the pinned version from there.
+2. **Locate the current official source.** Prefer, in order: the
+   library's own docs site, its GitHub README/CHANGELOG/release notes,
+   its published API reference. Avoid third-party tutorials — they lag
+   the real docs and can already be stale themselves.
+3. **Fetch the relevant pages.** Pull the API reference for the symbols
+   in question and the changelog or release notes since the version in
+   use (or since a recent baseline if no version is known).
+4. **Report the delta.** List what differs from the commonly assumed or
+   older API: renamed or removed functions, new required parameters,
+   deprecation notices, breaking changes, migration notes.
+5. **If a target file is given**, point out each call site that uses an
+   outdated API as `file:line`, with the corrected current call.
+6. **Cite sources** with the URL and, if visible, the doc's version or
+   date. A docs page with no version marker is weaker evidence than one
+   that names a release.
+
+## Rules
+
+- Never report a deprecation or rename from memory. Confirm it against
+  a page fetched during this run.
+- If the docs can't be reached — a private package, no public docs —
+  say so plainly instead of falling back to training-data assumptions.


### PR DESCRIPTION
## Summary
- Adds `best-practices/` — researches current idioms for a stack (language/framework/library) from official docs and style guides, then either answers a question directly or reviews given code against those patterns, flagging concrete deviations.
- Adds `latest-docs/` — fetches a library's current official documentation/changelog on request and reports the delta against what training data or existing code assumes (renamed/removed APIs, new required params, deprecations).
- Updates `README.md`'s skills table and install/update commands to include both new skills alongside `solidity-auditor`.
- Updates `CLAUDE.md`'s structure listing.

Both are general-purpose (not Solidity-specific) and follow the repo's existing skill conventions: single purpose, `description` frontmatter with explicit "Use when..." triggers, no fabricated examples, sources must be grounded in docs fetched during the run rather than training-data memory.

## Test plan
- [ ] `best-practices/SKILL.md` and `latest-docs/SKILL.md` frontmatter parses correctly and each stays under the repo's ~100-line SKILL.md guideline
- [ ] Skills install correctly via the updated README commands (`cp -r skills/{solidity-auditor,best-practices,latest-docs} ...`)
- [ ] `/best-practices` and `/latest-docs` are invocable in Claude Code CLI / Cursor after install